### PR TITLE
Add a feature to use memchr's libc feature instead of its fallback

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ memchr = { version = "2.0", default-features = false }
 
 [features]
 alloc = []
+use_libc = ["memchr/libc"]


### PR DESCRIPTION
I ran into an issue where memchr's fallback implementation of the `memchr` function didn't work with what I'm targeting. Using libc's version requires the `libc` feature to be turned on, which it is by default. However, this crate puts `default-features = false`, which makes sense because default-features includes `use_std`, but it excludes `libc`.