### PR TITLE
Fix stable builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,10 @@ language: rust
 sudo: false
 
 rust:
-- nightly
+  - nightly
+  - beta
+  - stable
+  - 1.36.0
 
 before_script:
 - |
@@ -16,7 +19,6 @@ script:
 
 env:
   global:
-  - TRAVIS_CARGO_NIGHTLY_FEATURE=alloc
 
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ cstr_core
 
 This crate provides an implementation of `CStr` and `CString` which do not depend on the standard library and are suitable for `no_std` environments.
 
-`CString` support is only available if the `alloc` feature is enabled. Currently this only works on nightly since it uses the `alloc` crate. `CStr` is always available.
+`CString` support is only available if the `alloc` feature is enabled. `CStr` is always available.
 
 ### Documentation
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 #![no_std]
-#![cfg_attr(feature = "alloc", feature(alloc))]
 
 #[cfg(test)]
 #[macro_use]


### PR DESCRIPTION
- `alloc` no longer requires nightly toolchain
- modified `.travis.yml` to match your `intrusive-collections` crate:
    - builds against toolchains: nightly, stable, beta, 1.36.0
    - removed `TRAVIS_CARGO_NIGHTLY_FEATURE=alloc`