### PR TITLE
Updates to make features based on atomic ops optional, to support thumbv6m-none-eabi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,7 @@ cty = "0.2.1"
 memchr = { version = "2.2.1", default-features = false }
 
 [features]
+default = ["arc"]
 alloc = []
+arc = []
 use_libc = ["memchr/libc"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 #![no_std]
-#![cfg_attr(feature = "alloc", feature(alloc))]
 
 #[cfg(test)]
 #[macro_use]
@@ -21,6 +20,7 @@ extern crate cty;
 extern crate memchr;
 
 #[cfg(feature = "alloc")]
+#[cfg(feature = "arc")]
 use alloc::sync::Arc;
 #[cfg(feature = "alloc")]
 use alloc::borrow::{Borrow, Cow, ToOwned};
@@ -728,6 +728,7 @@ impl From<CString> for Box<CStr> {
 }
 
 #[cfg(feature = "alloc")]
+#[cfg(feature = "arc")]
 impl From<CString> for Arc<CStr> {
     #[inline]
     fn from(s: CString) -> Arc<CStr> {
@@ -737,6 +738,7 @@ impl From<CString> for Arc<CStr> {
 }
 
 #[cfg(feature = "alloc")]
+#[cfg(feature = "arc")]
 impl<'a> From<&'a CStr> for Arc<CStr> {
     #[inline]
     fn from(s: &CStr) -> Arc<CStr> {
@@ -1359,6 +1361,8 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "alloc")]
+    #[cfg(feature = "arc")]
     fn into_rc() {
         let orig: &[u8] = b"Hello, world!\0";
         let cstr = CStr::from_bytes_with_nul(orig).unwrap();


### PR DESCRIPTION
These modifications appear to build and work as expected on thumbv6 (without atomics) and thumbv7 (with atomics) system using the nightly toolchain.

Tests pass on x64_64 with both stable and nightly toolchains.

I am not quite sure if the arrangement for the added `nightly` feature is not the correct way to gate the needed attributes since this means that functionality would be lost going from 0.1.2 -> 0.1.3 (this version) when using stable.

I am also not sure if the caution around keeping the vestigial `alloc` feature is needed, or if it should be dropped entirely.