### PR TITLE
Made memchr a feature flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ script:
 - travis-cargo build
 - travis-cargo build --features alloc
 - travis-cargo test --features alloc
+- travis-cargo build --no-default-features
+- travis-cargo build --no-default-features --features alloc
+- travis-cargo build --no-default-features --features memchr
+- travis-cargo build --no-default-features --features libc
 - travis-cargo doc -- --no-deps
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,9 @@ script:
 - travis-cargo build --no-default-features --features libc
 - travis-cargo doc -- --no-deps
 
+env:
+  global:
+    - TRAVIS_CARGO_NIGHTLY_FEATURE=
+
 notifications:
   email: false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,8 @@ edition = "2018"
 
 [dependencies]
 cty = "0.2.1"
-memchr = { version = "2.3.3", default-features = false }
 
 [features]
 default = ["arc"]
 alloc = []
 arc = []
-use_libc = ["memchr/libc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,10 @@ edition = "2018"
 
 [dependencies]
 cty = "0.2.1"
+memchr = { version = "2.3.3", default-features = false, optional = true }
 
 [features]
-default = ["arc"]
+default = ["arc", "memchr"]
 alloc = []
 arc = []
+use_libc = ["memchr", "memchr/libc"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -345,7 +345,7 @@ impl CString {
     }
 
     fn _new(bytes: Vec<u8>) -> Result<CString, NulError> {
-        match memchr::memchr(0, &bytes) {
+        match bytes.iter().position(|b| *b == 0) {
             Some(i) => Err(NulError(i, bytes)),
             None => Ok(unsafe { CString::from_vec_unchecked(bytes) }),
         }
@@ -967,7 +967,7 @@ impl CStr {
     /// assert!(cstr.is_err());
     /// ```
     pub fn from_bytes_with_nul(bytes: &[u8]) -> Result<&CStr, FromBytesWithNulError> {
-        let nul_pos = memchr::memchr(0, bytes);
+        let nul_pos = bytes.iter().position(|b| *b == 0);
         if let Some(nul_pos) = nul_pos {
             if nul_pos + 1 != bytes.len() {
                 return Err(FromBytesWithNulError::interior_nul(nul_pos));


### PR DESCRIPTION
I ran into an issue where I used `cstr_core` in a project where I also used `bindgen`. Both projects depended on `memchr`, but even if bindgen was a build-dependency, rust would still think that `cstr_core` depended on the same `memchr` with the same features. This would result in `cstr_core` needing `std`, which I didn't have in my project.

Removing `memchr` as a dependency made my project compile. Although `memchr` is faster, I figured it would be nice if people had the option to remove it as a dependency. I added a fallback implementation which is `.iter().position(|b| *b == 0)`.

I also added some more build steps to travis to check multiple combinations of features.