### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,14 @@ rust:
 - stable
 - 1.42.0
 
-before_script:
-- |
-  pip install 'travis-cargo<0.2' --user &&
-  export PATH=$HOME/.local/bin:$PATH
-
 script:
-- travis-cargo build
-- travis-cargo build --features alloc
-- travis-cargo test --features alloc
-- travis-cargo doc -- --no-deps
+- cargo build
+- cargo build --features alloc
+- cargo test --features alloc
+- cargo build --no-default-features
+- cargo build --no-default-features --features alloc
+- cargo build --no-default-features --features use_libc
+- cargo doc --no-deps
 
 notifications:
   email: false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,6 +209,7 @@ pub struct CString {
 /// ```
 ///
 /// [`CString`]: struct.CString.html
+/// [`String`]: https://doc.rust-lang.org/std/string/struct.String.html
 /// [`from_ptr`]: #method.from_ptr
 #[derive(Hash)]
 // FIXME:


### PR DESCRIPTION
Travis-cargo inserts a `--feature unstable` automatically when building on nightly. [The docs](https://github.com/huonw/travis-cargo#travis-cargo) specifically mention:
```
If you do not wish to define an unstable or similar feature, setting TRAVIS_CARGO_NIGHTLY_FEATURE="" should avoid errors caused by undefined features.
```
But I couldn't get Travis to cooperate, and it seemed simpler to me to just use cargo directly.

Also fixed a minor documentation issue where ```[`String`]``` was referenced but does not exist. I've made it redirect to the stable docs directly.