### PR TITLE
alloc is now stable (fixes #4)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ cty = "0.2.1"
 memchr = { version = "2.3.3", default-features = false }
 
 [features]
-default = ["arc"]
+default = ["arc", "alloc"]
 alloc = []
 arc = []
 use_libc = ["memchr/libc"]


### PR DESCRIPTION
Rust 1.36 stabilized the alloc crate more than a year ago.
Therefore it is not longer needed to check for the alloc feature
which effectively denied the use of CString in the stable compiler.