### PR TITLE
Make CStr::from_bytes_with_nul_unchecked evokable in const contexts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,5 @@ memchr = { version = "2.3.3", default-features = false }
 default = ["arc", "alloc"]
 alloc = []
 arc = []
-const_unsafe_new = []
+nightly = []
 use_libc = ["memchr/libc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,5 @@ memchr = { version = "2.3.3", default-features = false }
 default = ["arc", "alloc"]
 alloc = []
 arc = []
+const_unsafe_new = []
 use_libc = ["memchr/libc"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This crate provides an implementation of `CStr` and `CString` which do not depen
 `CString` support is only available if the `alloc` feature is enabled, which requires the `alloc` crate.
 `CStr` is always available.
 
-Some hardware targets (e.g. thumbv6m-none-eabi for Cortex M0,M0+) have no support for atomic operations. For these platforms, disable the `arc` feature to omit the parts of the crate that depend on atomic operations. Compatibility with thead-safe code and `Arc<T>` will not be available.
+Some hardware targets (e.g. thumbv6m-none-eabi for Cortex M0,M0+) have no support for atomic operations. For these platforms, disable the `arc` feature to omit the parts of the crate that depend on atomic operations. Compatibility with thead-safe code and `Arc<T>` will not be available. In addition, the `const_new_unsafe` feature allows the usage of `CStr::from_bytes_with_nul_unchecked` to be used in a `const` context. However, it requires a nightly version of the compiler.
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ This crate provides an implementation of `CStr` and `CString` which do not depen
 `CString` support is only available if the `alloc` feature is enabled, which requires the `alloc` crate.
 `CStr` is always available.
 
-Some hardware targets (e.g. thumbv6m-none-eabi for Cortex M0,M0+) have no support for atomic operations. For these platforms, disable the `arc` feature to omit the parts of the crate that depend on atomic operations. Compatibility with thead-safe code and `Arc<T>` will not be available. In addition, the `nightly` feature allows the usage of `CStr::from_bytes_with_nul_unchecked` to be used in a `const` context. However, it requires a nightly version of the compiler.
+Some hardware targets (e.g. thumbv6m-none-eabi for Cortex M0,M0+) have no support for atomic operations. For these platforms, disable the `arc` feature to omit the parts of the crate that depend on atomic operations. Compatibility with thead-safe code and `Arc<T>` will not be available. 
+
+In addition, the `nightly` feature allows the usage of `CStr::from_bytes_with_nul_unchecked` to be used in a `const` context. However, it requires a nightly version of the compiler.
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This crate provides an implementation of `CStr` and `CString` which do not depen
 `CString` support is only available if the `alloc` feature is enabled, which requires the `alloc` crate.
 `CStr` is always available.
 
-Some hardware targets (e.g. thumbv6m-none-eabi for Cortex M0,M0+) have no support for atomic operations. For these platforms, disable the `arc` feature to omit the parts of the crate that depend on atomic operations. Compatibility with thead-safe code and `Arc<T>` will not be available. In addition, the `const_new_unsafe` feature allows the usage of `CStr::from_bytes_with_nul_unchecked` to be used in a `const` context. However, it requires a nightly version of the compiler.
+Some hardware targets (e.g. thumbv6m-none-eabi for Cortex M0,M0+) have no support for atomic operations. For these platforms, disable the `arc` feature to omit the parts of the crate that depend on atomic operations. Compatibility with thead-safe code and `Arc<T>` will not be available. In addition, the `nightly` feature allows the usage of `CStr::from_bytes_with_nul_unchecked` to be used in a `const` context. However, it requires a nightly version of the compiler.
 
 ### Documentation
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 #![warn(rust_2018_idioms)]
-#![cfg_attr(feature = "const_unsafe_new", feature(const_raw_ptr_deref))]
+#![cfg_attr(feature = "nightly", feature(const_raw_ptr_deref))]
 
 #[cfg(test)]
 extern crate std;
@@ -997,7 +997,7 @@ impl CStr {
     ///     assert_eq!(cstr, &*cstring);
     /// }
     /// ```
-    #[cfg(feature = "const_unsafe_new")]
+    #[cfg(feature = "nightly")]
     #[inline]
     pub const unsafe fn from_bytes_with_nul_unchecked(bytes: &[u8]) -> &CStr {
         &*(bytes as *const [u8] as *const CStr)
@@ -1020,7 +1020,7 @@ impl CStr {
     ///     assert_eq!(cstr, &*cstring);
     /// }
     /// ```
-    #[cfg(not(feature = "const_unsafe_new"))]
+    #[cfg(not(feature = "nightly"))]
     #[inline]
     pub unsafe fn from_bytes_with_nul_unchecked(bytes: &[u8]) -> &CStr {
         &*(bytes as *const [u8] as *const CStr)
@@ -1440,7 +1440,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "const_unsafe_new")]
+    #[cfg(feature = "nightly")]
     fn const_cstr() {
         const TESTING_CSTR: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"Hello world!\0") };
         let _ = TESTING_CSTR.as_ptr(); 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![warn(rust_2018_idioms)]
+#![cfg_attr(feature = "const_unsafe_new", feature(const_raw_ptr_deref))]
 
 #[cfg(test)]
 extern crate std;
@@ -996,6 +997,30 @@ impl CStr {
     ///     assert_eq!(cstr, &*cstring);
     /// }
     /// ```
+    #[cfg(feature = "const_unsafe_new")]
+    #[inline]
+    pub const unsafe fn from_bytes_with_nul_unchecked(bytes: &[u8]) -> &CStr {
+        &*(bytes as *const [u8] as *const CStr)
+    }
+
+    /// Unsafely creates a C string wrapper from a byte slice.
+    ///
+    /// This function will cast the provided `bytes` to a `CStr` wrapper without
+    /// performing any sanity checks. The provided slice **must** be nul-terminated
+    /// and not contain any interior nul bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cstr_core::{CStr, CString};
+    ///
+    /// unsafe {
+    ///     let cstring = CString::new("hello").expect("CString::new failed");
+    ///     let cstr = CStr::from_bytes_with_nul_unchecked(cstring.to_bytes_with_nul());
+    ///     assert_eq!(cstr, &*cstring);
+    /// }
+    /// ```
+    #[cfg(not(feature = "const_unsafe_new"))]
     #[inline]
     pub unsafe fn from_bytes_with_nul_unchecked(bytes: &[u8]) -> &CStr {
         &*(bytes as *const [u8] as *const CStr)
@@ -1412,5 +1437,12 @@ mod tests {
 
         assert_eq!(&*rc2, cstr);
         assert_eq!(&*arc2, cstr);
+    }
+
+    #[test]
+    #[cfg(feature = "const_unsafe_new")]
+    fn const_cstr() {
+        const TESTING_CSTR: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"Hello world!\0") };
+        let _ = TESTING_CSTR.as_ptr(); 
     }
 }


### PR DESCRIPTION
This pull request resolves #14 by adding the `nightly` feature. When this feature is enabled, it changes `CStr::from_bytes_with_nul_unchecked` to be usable in `const` contexts. I have updated the tests and the `README.md` to reflect this feature.