### PR TITLE
Add std conversions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ script:
 - cargo build
 - cargo build --features alloc
 - cargo test --features alloc
+- cargo build --features std
 - cargo build --no-default-features
 - cargo build --no-default-features --features alloc
 - cargo build --no-default-features --features use_libc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ memchr = { version = "2.3.3", default-features = false }
 [features]
 default = ["arc", "alloc"]
 alloc = []
+std = []
 arc = []
 nightly = []
 use_libc = ["memchr/libc"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -813,13 +813,15 @@ use std::ffi::{CStr as StdCStr, CString as StdCString};
 
 #[cfg(feature = "std")]
 impl From<CString> for StdCString {
+    #[inline]
     fn from(s: CString) -> StdCString {
-        unsafe { StdCString::from_raw(s.into_raw()) }
+        unsafe { StdCString::from_vec_unchecked(s.into_bytes_with_nul()) }
     }
 }
 
 #[cfg(feature = "std")]
 impl<'a> From<&'a CStr> for &'a StdCStr {
+    #[inline]
     fn from(s: &'a CStr) -> &'a StdCStr {
         s.as_ref()
     }
@@ -827,27 +829,31 @@ impl<'a> From<&'a CStr> for &'a StdCStr {
 
 #[cfg(feature = "std")]
 impl From<StdCString> for CString {
+    #[inline]
     fn from(s: StdCString) -> CString {
-        unsafe { CString::from_raw(s.into_raw()) }
+        unsafe { CString::from_vec_unchecked(s.into_bytes_with_nul()) }
     }
 }
 
 #[cfg(feature = "std")]
 impl<'a> From<&'a StdCStr> for &'a CStr {
+    #[inline]
     fn from(s: &'a StdCStr) -> &'a CStr {
-        unsafe { CStr::from_ptr(s.as_ptr()) }
+        unsafe { CStr::from_bytes_with_nul_unchecked(s.to_bytes_with_nul()) }
     }
 }
 
 #[cfg(feature = "std")]
 impl AsRef<StdCStr> for CString {
+    #[inline]
     fn as_ref(&self) -> &StdCStr {
-        unsafe { StdCStr::from_ptr(self.as_ptr()) }
+        unsafe { StdCStr::from_bytes_with_nul_unchecked(self.to_bytes_with_nul()) }
     }
 }
 
 #[cfg(feature = "std")]
 impl Borrow<StdCStr> for CString {
+    #[inline]
     fn borrow(&self) -> &StdCStr {
         self.as_ref()
     }
@@ -855,8 +861,9 @@ impl Borrow<StdCStr> for CString {
 
 #[cfg(feature = "std")]
 impl AsRef<StdCStr> for CStr {
+    #[inline]
     fn as_ref(&self) -> &StdCStr {
-        unsafe { StdCStr::from_ptr(self.as_ptr()) }
+        unsafe { StdCStr::from_bytes_with_nul_unchecked(self.to_bytes_with_nul()) }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -815,7 +815,7 @@ use std::ffi::{CStr as StdCStr, CString as StdCString};
 impl From<CString> for StdCString {
     #[inline]
     fn from(s: CString) -> StdCString {
-        unsafe { StdCString::from_vec_unchecked(s.into_bytes_with_nul()) }
+        unsafe { StdCString::from_vec_unchecked(s.into_bytes()) }
     }
 }
 
@@ -831,7 +831,7 @@ impl<'a> From<&'a CStr> for &'a StdCStr {
 impl From<StdCString> for CString {
     #[inline]
     fn from(s: StdCString) -> CString {
-        unsafe { CString::from_vec_unchecked(s.into_bytes_with_nul()) }
+        unsafe { CString::from_vec_unchecked(s.into_bytes()) }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![warn(rust_2018_idioms)]
 #![cfg_attr(feature = "nightly", feature(const_raw_ptr_deref))]
 
@@ -805,6 +805,58 @@ impl Default for Box<CStr> {
     fn default() -> Box<CStr> {
         let boxed: Box<[u8]> = Box::from([0]);
         unsafe { Box::from_raw(Box::into_raw(boxed) as *mut CStr) }
+    }
+}
+
+#[cfg(feature = "std")]
+use std::ffi::{CStr as StdCStr, CString as StdCString};
+
+#[cfg(feature = "std")]
+impl From<CString> for StdCString {
+    fn from(s: CString) -> StdCString {
+        unsafe { StdCString::from_raw(s.into_raw()) }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<'a> From<&'a CStr> for &'a StdCStr {
+    fn from(s: &'a CStr) -> &'a StdCStr {
+        s.as_ref()
+    }
+}
+
+#[cfg(feature = "std")]
+impl From<StdCString> for CString {
+    fn from(s: StdCString) -> CString {
+        unsafe { CString::from_raw(s.into_raw()) }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<'a> From<&'a StdCStr> for &'a CStr {
+    fn from(s: &'a StdCStr) -> &'a CStr {
+        unsafe { CStr::from_ptr(s.as_ptr()) }
+    }
+}
+
+#[cfg(feature = "std")]
+impl AsRef<StdCStr> for CString {
+    fn as_ref(&self) -> &StdCStr {
+        unsafe { StdCStr::from_ptr(self.as_ptr()) }
+    }
+}
+
+#[cfg(feature = "std")]
+impl Borrow<StdCStr> for CString {
+    fn borrow(&self) -> &StdCStr {
+        self.as_ref()
+    }
+}
+
+#[cfg(feature = "std")]
+impl AsRef<StdCStr> for CStr {
+    fn as_ref(&self) -> &StdCStr {
+        unsafe { StdCStr::from_ptr(self.as_ptr()) }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -847,7 +847,7 @@ impl<'a> From<&'a StdCStr> for &'a CStr {
 impl AsRef<StdCStr> for CString {
     #[inline]
     fn as_ref(&self) -> &StdCStr {
-        unsafe { StdCStr::from_bytes_with_nul_unchecked(self.to_bytes_with_nul()) }
+        AsRef::<CStr>::as_ref(self).as_ref()
     }
 }
 


### PR DESCRIPTION
It's quite handy for some crates to support both std and no_std builds. This patch adds related impls like `From`/`AsRef`/`Borrow` for compatibility with std types behind a disabled-by-default feature.