### PR TITLE
Made the memchr dependency optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ script:
 - cargo build --features std
 - cargo build --no-default-features
 - cargo build --no-default-features --features alloc
+- cargo build --no-default-features --features memchr
 - cargo build --no-default-features --features use_libc
 - cargo doc --no-deps
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,12 @@ edition = "2018"
 
 [dependencies]
 cty = "0.2.1"
-memchr = { version = "2.3.3", default-features = false }
+memchr = { version = "2.3.3", default-features = false, optional = true }
 
 [features]
-default = ["arc", "alloc"]
+default = ["arc", "alloc", "memchr"]
 alloc = []
 std = []
 arc = []
 nightly = []
-use_libc = ["memchr/libc"]
+use_libc = ["memchr", "memchr/libc"]


### PR DESCRIPTION
I love cstr_core, however in every embedded project I try to use it, the `memchr` dependency tries to pull in `std` and it fails.

I'm not sure why it does this, the `use_libc` feature should fix this but it doesn't. This compiles:

```toml
[dependencies.cstr_core]
git = "https://github.com/victorkoenders/cstr_core"
default-features = false
```

```bash
+ cargo build --target riscv32i-unknown-none-elf
   Compiling esp32c3_test v0.1.0 (/home/trangar/development/rust/esp32c3_test)
    Finished dev [unoptimized + debuginfo] target(s) in 0.62s
```

And this doesn't:

```toml
[dependencies.cstr_core]
git = "https://github.com/victorkoenders/cstr_core"
default-features = false
features = ["use_libc"]
```

```bash
+ cargo build --target riscv32i-unknown-none-elf
    Blocking waiting for file lock on build directory
   Compiling esp32c3_test v0.1.0 (/home/trangar/development/rust/esp32c3_test)
   Compiling memchr v2.4.0
   Compiling riscv-rt v0.8.0
   Compiling esp32c3 v0.1.2
error[E0463]: can't find crate for `std`
  |
  = note: the `riscv32i-unknown-none-elf` target may not support the standard library
  = note: `std` is required by `memchr` because it does not declare `#![no_std]`
  = help: consider building the standard library from source with `cargo build -Zbuild-std`
  ```

Since `memchr` is only used in 2 places, and in my usecase I don't need the performance increase, it would be nice if I could completely disable the `memchr` dependency. 