### PR TITLE
Nightly constify to_str (and everything on its path)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1180,6 +1180,32 @@ impl CStr {
     /// assert_eq!(cstr.to_bytes_with_nul(), b"foo\0");
     /// ```
     #[inline]
+    #[cfg(feature = "nightly")]
+    pub const fn to_bytes_with_nul(&self) -> &[u8] {
+        unsafe { &*(&self.inner as *const [c_char] as *const [u8]) }
+    }
+
+    /// Converts this C string to a byte slice containing the trailing 0 byte.
+    ///
+    /// This function is the equivalent of [`to_bytes`] except that it will retain
+    /// the trailing nul terminator instead of chopping it off.
+    ///
+    /// > **Note**: This method is currently implemented as a 0-cost cast, but
+    /// > it is planned to alter its definition in the future to perform the
+    /// > length calculation whenever this method is called.
+    ///
+    /// [`to_bytes`]: #method.to_bytes
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cstr_core::CStr;
+    ///
+    /// let cstr = CStr::from_bytes_with_nul(b"foo\0").expect("CStr::from_bytes_with_nul failed");
+    /// assert_eq!(cstr.to_bytes_with_nul(), b"foo\0");
+    /// ```
+    #[inline]
+    #[cfg(not(feature = "nightly"))]
     pub fn to_bytes_with_nul(&self) -> &[u8] {
         unsafe { &*(&self.inner as *const [c_char] as *const [u8]) }
     }


### PR DESCRIPTION
This constifies `to_str` in three progressive steps.

Two new features are enabled at nightly [const_str_from_utf8](https://github.com/rust-lang/rust/issues/91006) and [const_slice_from_raw_parts](https://github.com/rust-lang/rust/issues/67456). The former is rather new (but appears to be unproblematic), the latter has been around for over a year (and doesn't look troublesome either).

Two functions (`to_str`, `to_bytes_with_nul`) are constified without actual code changes; `to_bytes` needs code changes for nightly (it builds the slice through unsafe from_parts rather than slicing). If the former are too much duplication, it'd be an option to pull in [const_ft](https://docs.rs/const-ft/0.1.2/const_ft/) to let preprocessor do it, similar to how Rust itself uses `rustc_const_unstable`. (Might actually not be a dependency but copied in, because it's using a hardcoded feature name that is not "nighlty").