### PR TITLE
Constify from_bytes_with_nul

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,12 +282,12 @@ enum FromBytesWithNulErrorKind {
 }
 
 impl FromBytesWithNulError {
-    fn interior_nul(pos: usize) -> FromBytesWithNulError {
+    const fn interior_nul(pos: usize) -> FromBytesWithNulError {
         FromBytesWithNulError {
             kind: FromBytesWithNulErrorKind::InteriorNul(pos),
         }
     }
-    fn not_nul_terminated() -> FromBytesWithNulError {
+    const fn not_nul_terminated() -> FromBytesWithNulError {
         FromBytesWithNulError {
             kind: FromBytesWithNulErrorKind::NotNulTerminated,
         }


### PR DESCRIPTION
See discussion in https://github.com/Amanieu/cstr_core/issues/23.

This constifies some constructors, adds a const-if-on-nightly version of memchr (using const_eval_select to dispatch), and then does the trivial remaining constify-by-duplication of from_bytes_with_nul.