### PR TITLE
feature "nightly": Add core_intrinsics compiler feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 #![cfg_attr(feature = "nightly", feature(const_slice_from_raw_parts))]
 #![cfg_attr(feature = "nightly", feature(const_str_from_utf8))]
 #![cfg_attr(feature = "nightly", feature(const_eval_select))]
+#![cfg_attr(feature = "nightly", feature(core_intrinsics))]
 
 #[cfg(test)]
 extern crate std;


### PR DESCRIPTION
This has become necessary to access the const_eval_select in some
nightly after nightly-2022-03-08.

---

I didn't find where the change happened exactly in Rust, but needing to track this kind of changes is kind of expected with the nightly feature set.